### PR TITLE
fix vcpkg error when building devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,7 +42,9 @@ RUN apt update \
 # Install vcpkg dependency manager
 RUN git clone https://github.com/Microsoft/vcpkg ${VCPKG_ROOT} \
     && cd ${VCPKG_ROOT} \
-    && ./bootstrap-vcpkg.sh
+    && ./bootstrap-vcpkg.sh \
+    && mkdir /root/.vcpkg \
+    && touch /root/.vcpkg/vcpkg.path.txt
 
 ENV PATH "${VCPKG_ROOT}:${PATH}"
 


### PR DESCRIPTION
When building container in codespace， The following error occurred:

[dev_container_auto_added_stage_label 5/5] RUN vcpkg integrate install     && vcpkg integrate bash
0.643 write_contents("/root/.vcpkg/vcpkg.path.txt"): No such file or directory
ERROR: executor failed running [/bin/sh -c vcpkg integrate install     && vcpkg integrate bash]: exit code: 1