### PR TITLE
Fix TX_THREAD_ENABLE_PERFORMANCE_INFO not being applied

### DIFF
--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -6,7 +6,7 @@ set(THREADX_ARCH "linux")
 set(THREADX_TOOLCHAIN "gnu")
 
 # Define the ThreadX options that will be used by projects
-set(TX_THREAD_ENABLE_PERFORMANCE_INFO)
+add_definitions(-DTX_THREAD_ENABLE_PERFORMANCE_INFO)
 
 # Use vcpkg toolchain file
 set(VCPKG_CMAKE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")


### PR DESCRIPTION
The last fix for #1 did not work, as it just set a cmake variable that the program was unaware of.
This change adds TX_THREAD_ENABLE_PERFORMANCE_INFO as a preprocessor definition, and I have confirmed it fixes ProjectAnalyze.